### PR TITLE
Updated deps & fixed tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,25 +11,25 @@ repository = "https://github.com/phayes/ecies-ed25519"
 readme = "README.md"
 
 [dependencies]
-rand = "0.7.3"
-curve25519-dalek = "3.1.0"
-thiserror = "1.0.24"
+rand = "0.8.5"
+curve25519-dalek = { version = "4.1.3", features = ["legacy_compatibility"] }
+thiserror = "1.0.64"
 hex = "0.4.3"
-zeroize = "1.3.0"
+zeroize = "1.8.1"
 # "serde" feature
-serde = { version = "1.0.125", optional = true }
+serde = { version = "1.0.210", optional = true }
 # "ring" feature
-ring = { version = "0.16.20", optional = true, features = [] }
+ring = { version = "0.17.8", optional = true, features = [] }
 # "pure_rust" feature
-aes-gcm = { version = "0.8.0", optional = true }
-sha2 = { version = "0.9.3", optional = true }
-digest = { version = "0.9.0", optional = true }
-hkdf = { version = "0.10.0", optional = true }
+aes-gcm = { version = "0.10.3", optional = true }
+sha2 = { version = "0.10.8", optional = true }
+digest = { version = "0.10.7", optional = true }
+hkdf = { version = "0.12.4", optional = true }
 
 [features]
 default = ["pure_rust"]
 pure_rust = ["aes-gcm", "sha2", "digest", "hkdf"]
 
 [dev-dependencies]
-serde_json = "1.0.64"
-serde_cbor = "0.11.1"
+serde_json = "1.0.128"
+serde_cbor = "0.11.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,10 +257,10 @@ pub mod tests {
 
     #[test]
     fn test_aes_interop() {
-        let mut test_rng = rand::rngs::StdRng::from_seed([0u8; 32]);
-
-        let mut key = [0u8; 32];
-        test_rng.fill_bytes(&mut key);
+        let key = [
+            118, 184, 224, 173, 160, 241, 61, 144, 64, 93, 106, 229, 83, 134, 189, 40, 189, 210,
+            25, 184, 160, 141, 237, 26, 168, 54, 239, 204, 139, 119, 13, 199,
+        ];
 
         let plaintext = b"ABC";
 
@@ -275,9 +275,10 @@ pub mod tests {
 
     #[test]
     fn test_ecies_ed25519_interop() {
-        let mut test_rng = rand::rngs::StdRng::from_seed([0u8; 32]);
-
-        let (peer_sk, _peer_pk) = generate_keypair(&mut test_rng);
+        let peer_sk = SecretKey([
+            118, 184, 224, 173, 160, 241, 61, 144, 64, 93, 106, 229, 83, 134, 189, 40, 189, 210,
+            25, 184, 160, 141, 237, 26, 168, 54, 239, 204, 139, 119, 13, 199,
+        ]);
 
         let plaintext = b"ABC";
         let known_encrypted: Vec<u8> = vec![
@@ -397,8 +398,8 @@ pub mod tests {
         assert_eq!(public.as_bytes(), deserialized_public.as_bytes());
 
         // Test errors - mangle some bits and confirm it doesn't work:
-        let mut serialized_public = serde_cbor::to_vec(&public).unwrap();
-        serialized_public[6] = 120;
+        let mut serialized_public = serialized_public;
+        serialized_public[6] ^= 0xFF;
         assert!(serde_cbor::from_slice::<PublicKey>(&serialized_public).is_err());
     }
 }

--- a/src/pure_rust_backend.rs
+++ b/src/pure_rust_backend.rs
@@ -1,4 +1,4 @@
-use aes_gcm::aead::{self, generic_array::GenericArray, Aead, NewAead};
+use aes_gcm::aead::{self, generic_array::GenericArray, Aead, KeyInit};
 use aes_gcm::Aes256Gcm;
 use hkdf::Hkdf;
 use rand::{CryptoRng, RngCore};


### PR DESCRIPTION
Tests depend on the specific (seeded) rand output, instead of doing that, bake the byte arrays into the tests.

Also update the dependencies to the newest versions