### PR TITLE
chore(deps): upgrade all deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,25 +11,26 @@ repository = "https://github.com/phayes/ecies-ed25519"
 readme = "README.md"
 
 [dependencies]
-rand = "0.8.5"
-curve25519-dalek = { version = "4.1.3", features = ["legacy_compatibility"] }
-thiserror = "1.0.64"
+rand_core = "0.10.1"
+curve25519-dalek = { version = "5.0.0", features = ["legacy_compatibility"] }
+thiserror = "2.0.18"
 hex = "0.4.3"
-zeroize = "1.8.1"
+zeroize = "1.9.0"
 # "serde" feature
-serde = { version = "1.0.210", optional = true }
+serde = { version = "1.0.228", optional = true }
 # "ring" feature
-ring = { version = "0.17.8", optional = true, features = [] }
+ring = { version = "0.17.14", optional = true, features = [] }
 # "pure_rust" feature
-aes-gcm = { version = "0.10.3", optional = true }
-sha2 = { version = "0.10.8", optional = true }
-digest = { version = "0.10.7", optional = true }
-hkdf = { version = "0.12.4", optional = true }
+aes-gcm = { version = "0.11.0", optional = true }
+sha2 = { version = "0.11.0", optional = true }
+digest = { version = "0.11.3", optional = true }
+hkdf = { version = "0.13.0", optional = true }
 
 [features]
 default = ["pure_rust"]
 pure_rust = ["aes-gcm", "sha2", "digest", "hkdf"]
 
 [dev-dependencies]
-serde_json = "1.0.128"
+rand = "0.10.2"
+serde_json = "1.0.150"
 serde_cbor = "0.11.2"

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ It uses the excellent [curve25519-dalek](https://github.com/dalek-cryptography/c
 
 2. The `ring` backend uses [ring](https://github.com/briansmith/ring).  It uses rock solid primitives based on BoringSSL, but cannot run on all platforms. For example it won't work on WASM. To activate this backend add this to your Cargo.toml file: 
 
-   ` ecies-ed25519 = { version = "0.3", features = ["ring"] }`
+   ` ecies-ed25519 = { version = "0.5", features = ["ring"] }`
 
 ### Example Usage
 ```rust
-let mut csprng = rand::thread_rng();
+let mut csprng = rand::rng();
 let (secret, public) = ecies_ed25519::generate_keypair(&mut csprng);
 
 let message = "I 💖🔒";

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -4,7 +4,7 @@ use curve25519_dalek::constants;
 use curve25519_dalek::edwards::{CompressedEdwardsY, EdwardsPoint};
 use curve25519_dalek::scalar::Scalar;
 use hex::{FromHex, ToHex};
-use rand::{CryptoRng, RngCore};
+use rand_core::CryptoRng;
 use zeroize::Zeroize;
 
 /// The length of a `SecretKey`, in bytes.
@@ -101,7 +101,7 @@ impl SecretKey {
     /// Generate a `SecretKey` from a `csprng`.
     pub fn generate<T>(csprng: &mut T) -> SecretKey
     where
-        T: CryptoRng + RngCore,
+        T: CryptoRng,
     {
         let mut sk: SecretKey = SecretKey([0u8; 32]);
         csprng.fill_bytes(&mut sk.0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //! ## Example Usage
 //! ```rust
-//! let mut csprng = rand::thread_rng();
+//! let mut csprng = rand::rng();
 //! let (secret, public) = ecies_ed25519::generate_keypair(&mut csprng);
 //!
 //! let message = "I 💖🔒";
@@ -33,7 +33,7 @@
 //!
 
 use curve25519_dalek::scalar::Scalar;
-use rand::{CryptoRng, RngCore};
+use rand_core::CryptoRng;
 
 mod keys;
 pub use keys::*;
@@ -68,14 +68,14 @@ type AesKey = [u8; 32];
 type SharedSecret = [u8; 32];
 
 /// Generate a keypair, ready for use in ECIES
-pub fn generate_keypair<R: CryptoRng + RngCore>(rng: &mut R) -> (SecretKey, PublicKey) {
+pub fn generate_keypair<R: CryptoRng>(rng: &mut R) -> (SecretKey, PublicKey) {
     let secret = SecretKey::generate(rng);
     let public = PublicKey::from_secret(&secret);
     (secret, public)
 }
 
 /// Encrypt a message using ECIES, it can only be decrypted by the receiver's SecretKey.
-pub fn encrypt<R: CryptoRng + RngCore>(
+pub fn encrypt<R: CryptoRng>(
     receiver_pub: &PublicKey,
     msg: &[u8],
     rng: &mut R,
@@ -175,13 +175,13 @@ pub enum Error {
 pub mod tests {
     use super::*;
 
-    use rand::thread_rng;
-    use rand::SeedableRng;
+    use rand::{Rng, SeedableRng};
 
     #[test]
     fn test_shared() {
-        let (emphemeral_sk, emphemeral_pk) = generate_keypair(&mut thread_rng());
-        let (peer_sk, peer_pk) = generate_keypair(&mut thread_rng());
+        let mut rng = rand::rng();
+        let (emphemeral_sk, emphemeral_pk) = generate_keypair(&mut rng);
+        let (peer_sk, peer_pk) = generate_keypair(&mut rng);
 
         assert_eq!(
             generate_shared(&emphemeral_sk, &peer_pk),
@@ -197,8 +197,9 @@ pub mod tests {
 
     #[test]
     fn test_encapsulation() {
-        let (emphemeral_sk, emphemeral_pk) = generate_keypair(&mut thread_rng());
-        let (peer_sk, peer_pk) = generate_keypair(&mut thread_rng());
+        let mut rng = rand::rng();
+        let (emphemeral_sk, emphemeral_pk) = generate_keypair(&mut rng);
+        let (peer_sk, peer_pk) = generate_keypair(&mut rng);
 
         assert_eq!(
             encapsulate(&emphemeral_sk, &peer_pk),
@@ -208,6 +209,7 @@ pub mod tests {
 
     #[test]
     fn test_aes() {
+        let mut rng = rand::rng();
         let mut test_rng = rand::rngs::StdRng::from_seed([0u8; 32]);
         let mut key = [0u8; 32];
         test_rng.fill_bytes(&mut key);
@@ -222,17 +224,18 @@ pub mod tests {
         assert!(aes_decrypt(&key, &[0u8; 16]).is_err());
 
         // Test bad secret key
-        let bad_secret = SecretKey::generate(&mut thread_rng());
+        let bad_secret = SecretKey::generate(&mut rng);
         assert!(aes_decrypt(bad_secret.as_bytes(), &encrypted).is_err());
     }
 
     #[test]
     fn test_ecies_ed25519() {
-        let (peer_sk, peer_pk) = generate_keypair(&mut thread_rng());
+        let mut rng = rand::rng();
+        let (peer_sk, peer_pk) = generate_keypair(&mut rng);
 
         let plaintext = b"ABOLISH ICE";
 
-        let encrypted = encrypt(&peer_pk, plaintext, &mut thread_rng()).unwrap();
+        let encrypted = encrypt(&peer_pk, plaintext, &mut rng).unwrap();
         let decrypted = decrypt(&peer_sk, &encrypted).unwrap();
 
         assert_eq!(plaintext, decrypted.as_slice());
@@ -241,7 +244,7 @@ pub mod tests {
         assert!(decrypt(&peer_sk, &[0u8; 16]).is_err());
 
         // Test that it fails when using a bad secret key
-        let bad_secret = SecretKey::generate(&mut thread_rng());
+        let bad_secret = SecretKey::generate(&mut rng);
         assert!(decrypt(&bad_secret, &encrypted).is_err());
     }
 

--- a/src/pure_rust_backend.rs
+++ b/src/pure_rust_backend.rs
@@ -1,7 +1,7 @@
-use aes_gcm::aead::{self, generic_array::GenericArray, Aead, KeyInit};
+use aes_gcm::aead::{self, Aead, KeyInit};
 use aes_gcm::Aes256Gcm;
 use hkdf::Hkdf;
-use rand::{CryptoRng, RngCore};
+use rand_core::CryptoRng;
 use sha2::Sha256;
 
 use super::AesKey;
@@ -18,21 +18,19 @@ pub(crate) fn hkdf_sha256(master: &[u8]) -> AesKey {
     out
 }
 
-pub(crate) fn aes_encrypt<R: CryptoRng + RngCore>(
+pub(crate) fn aes_encrypt<R: CryptoRng>(
     key: &AesKey,
     msg: &[u8],
     rng: &mut R,
 ) -> Result<Vec<u8>, Error> {
-    let key = GenericArray::from_slice(key);
-    let aead = Aes256Gcm::new(key);
+    let aead = Aes256Gcm::new(key.into());
 
     let mut nonce = [0u8; AES_IV_LENGTH];
     rng.try_fill_bytes(&mut nonce)
         .map_err(|_| Error::EncryptionFailedRng)?;
-    let nonce = GenericArray::from_slice(&nonce);
 
     let ciphertext = aead
-        .encrypt(nonce, msg)
+        .encrypt(&nonce.into(), msg)
         .map_err(|_| Error::EncryptionFailed)?;
 
     let mut output = Vec::with_capacity(AES_IV_LENGTH + ciphertext.len());
@@ -43,13 +41,11 @@ pub(crate) fn aes_encrypt<R: CryptoRng + RngCore>(
 }
 
 pub(crate) fn aes_decrypt(key: &AesKey, ciphertext: &[u8]) -> Result<Vec<u8>, aead::Error> {
-    let key = GenericArray::from_slice(key);
-    let aead = Aes256Gcm::new(key);
+    let aead = Aes256Gcm::new(key.into());
 
-    let nonce = GenericArray::from_slice(&ciphertext[..AES_IV_LENGTH]);
-    let encrypted = &ciphertext[AES_IV_LENGTH..];
+    let (nonce, encrypted) = ciphertext.split_first_chunk::<AES_IV_LENGTH>().unwrap();
 
-    let decrypted = aead.decrypt(nonce, encrypted)?;
+    let decrypted = aead.decrypt(nonce.into(), encrypted)?;
 
     Ok(decrypted)
 }

--- a/src/ring_backend.rs
+++ b/src/ring_backend.rs
@@ -1,4 +1,4 @@
-use rand::{CryptoRng, RngCore};
+use rand_core::CryptoRng;
 use ring::aead::*;
 use ring::hkdf::*;
 
@@ -23,7 +23,7 @@ pub(crate) fn hkdf_sha256(master: &[u8]) -> AesKey {
     out
 }
 
-pub(crate) fn aes_encrypt<R: CryptoRng + RngCore>(
+pub(crate) fn aes_encrypt<R: CryptoRng>(
     key: &AesKey,
     msg: &[u8],
     rng: &mut R,


### PR DESCRIPTION
Specially, update `rand` to `0.10` which requires a bunch of changes. As does the `aes-gcm` upgrade.

This needs a major version bump since the `rand` upgrade is breaking.